### PR TITLE
#64 Prevent undefined bodies

### DIFF
--- a/js/requests.service.js
+++ b/js/requests.service.js
@@ -25,7 +25,7 @@ clientApp.service('requests', function($http, $q, appHelper, auth, headers) {
 			method: $scope.requestMethod.selected,
 			url: $scope.requestUrl,
 			headers: requestHeaders,
-			data: $scope.payload,
+			data: $scope.payload || "",
 			timeout: canceller.promise
 		});
 		return promise;


### PR DESCRIPTION
#64 Use an empty string instead of 'undefined' for the request body. 